### PR TITLE
Update - Java 21 Instructions - Using-the-right-Java.md

### DIFF
--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -9,7 +9,7 @@ Snapshots 24w14a and later now require Java 21.
 
 Download: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
 
-### **Minecraft 1.17 and newer (Java 17)**
+### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
@@ -59,7 +59,7 @@ Snapshots 24w14a and later now require Java 21.
 
 Download: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
 
-### **Minecraft 1.17 and newer (Java 17)**
+### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
 
 Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=macos&architecture=x86-64-bit&package=jre>
@@ -88,7 +88,7 @@ Snapshots 24w14a and later now require Java 21.
 
 `temurin-21-jdk`
 
-### **Minecraft 1.17 and newer (Java 17)**
+### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
 * Ubuntu/Debian derivatives: `openjdk-17-jre`
 * Arch `jre17-openjdk`

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -5,8 +5,6 @@ If you don't know which one and how to get it, read on. After you installed the 
 
 ### **Minecraft 24w14a and newer (Java 21)**
 
-Snapshots 24w14a and later now require Java 21.
-
 Download: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
@@ -55,8 +53,6 @@ Scroll down until you see the single entry in the table!
 
 ### **Minecraft 24w14a and newer (Java 21)**
 
-Snapshots 24w14a and later now require Java 21.
-
 Download: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
@@ -83,8 +79,6 @@ Scroll down until you see the single entry in the table!
 # Linux
 
 ### **Minecraft 24w14a and newer (Java 21)**
-
-Snapshots 24w14a and later now require Java 21.
 
 `temurin-21-jdk`
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -57,7 +57,7 @@ Scroll down until you see the single entry in the table!
 
 Snapshots 24w14a and later now require Java 21.
 
-<https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
+Download: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
 
 ### **Minecraft 1.17 and newer (Java 17)**
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -35,7 +35,6 @@ Note: There is an exception when using some poorly supported/unsupported old int
 
 Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=8>
 
-Scroll down until you see the single entry in the table!
 <details>
   <summary>Other Distributions</summary>
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -5,7 +5,7 @@ If you don't know which one and how to get it, read on. After you installed the 
 
 ### **Minecraft 24w14a and newer (Java 21)**
 
-Download: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
@@ -13,14 +13,13 @@ Pick the JRE versions and make sure to match the architecture with your system, 
 
 **Make sure to download the .msi installer!**
 
-Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre>
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=17>
 
 Scroll down until you see the single entry in the table!
 <details>
 <summary>Other Distributions</summary>
 
-* Eclipse Temurin: <https://adoptium.net/temurin/releases/?version=17>
-  * Select in the dropdowns "Windows" "x64" "JRE" and "17"
+* Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre>
 * Microsoft OpenJDK: <https://docs.microsoft.com/en-gb/java/openjdk/download>
 * Oracle: <https://www.oracle.com/java/technologies/downloads/#java17>
 </details>   
@@ -34,14 +33,13 @@ Pick the JRE versions and make sure to match the architecture with your system, 
 
 Note: There is an exception when using some poorly supported/unsupported old integrated GPUs from Intel. See [[Unsupported-Intel-GPUs]] for details.
 
-Azul: <https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre>
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=8>
 
 Scroll down until you see the single entry in the table!
 <details>
   <summary>Other Distributions</summary>
 
-* Eclipse Temurin: <https://adoptium.net/temurin/releases/?version=8>
-  * Select in the dropdowns "Windows" "x64" "JRE" and "8"
+* Azul: <https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre>
 * Java.com: <https://www.java.com/en/download/manual.jsp>
   * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.  
 ![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
@@ -53,14 +51,13 @@ Scroll down until you see the single entry in the table!
 
 ### **Minecraft 24w14a and newer (Java 21)**
 
-Download: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=17>
 
-Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=macos&architecture=x86-64-bit&package=jre>
-
-For least amount of issues, choose **.dmg** download.
+For least amount of issues, choose **.pkg** download.
 
 Scroll down until you see the single entry in the table!
   

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -58,8 +58,6 @@ Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package
 Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=17>
 
 For least amount of issues, choose **.pkg** download.
-
-Scroll down until you see the single entry in the table!
   
 **Native ARM Java is currently not supported on MultiMC and x86_64 packages are required for M1/M2/M3 computers.**    
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -2,7 +2,13 @@ Generally you should use Java with the same architecture as your CPU. There are 
 If you don't know which one and how to get it, read on. After you installed the correct version make sure [to select it](#setting-up-java-in-multimc).
 
 # Windows  
-    
+
+### **Minecraft 24w14a and newer (Java 21)**
+
+Snapshots 24w14a and later now require Java 21.
+
+Download: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
+
 ### **Minecraft 1.17 and newer (Java 17)**
 
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
@@ -47,6 +53,12 @@ Scroll down until you see the single entry in the table!
 
 #  macOS #  
 
+### **Minecraft 24w14a and newer (Java 21)**
+
+Snapshots 24w14a and later now require Java 21.
+
+<https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
+
 ### **Minecraft 1.17 and newer (Java 17)**
 
 
@@ -70,6 +82,11 @@ Scroll down until you see the single entry in the table!
 
 # Linux
 
+### **Minecraft 24w14a and newer (Java 21)**
+
+Snapshots 24w14a and later now require Java 21.
+
+`temurin-21-jdk`
 
 ### **Minecraft 1.17 and newer (Java 17)**
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -3,9 +3,11 @@ If you don't know which one and how to get it, read on. After you installed the 
 
 # Windows  
 
-### **Minecraft 24w14a and newer (Java 21)**
+### **Minecraft 1.20.5 and newer (Java 21)**
 
 Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
+
+&nbsp;
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
@@ -22,7 +24,8 @@ Scroll down until you see the single entry in the table!
 * Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre>
 * Microsoft OpenJDK: <https://docs.microsoft.com/en-gb/java/openjdk/download>
 * Oracle: <https://www.oracle.com/java/technologies/downloads/#java17>
-</details>   
+</details>
+
 &nbsp;
 
 ### **Minecraft 1.16 and older (Java 8)**
@@ -43,38 +46,38 @@ Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&pac
   * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.  
 ![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
 </details>
+&nbsp;
+
+#  macOS #
+**M1/M2/M3 CPU: Native ARM Java is currently not supported on MultiMC and x86_64 packages are required.**
+
+For least amount of issues, choose **.pkg** download.
+
+### **Minecraft 1.20.5 and newer (Java 21)**
+Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
 
 &nbsp;
 
-#  macOS #  
-
-### **Minecraft 24w14a and newer (Java 21)**
-
-Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=21>
-
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
-
 Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=mac&arch=x64&package=jre&version=17>
-
-For least amount of issues, choose **.pkg** download.
   
-**Native ARM Java is currently not supported on MultiMC and x86_64 packages are required for M1/M2/M3 computers.**    
-
   
+&nbsp;
 
 ### **Minecraft 1.16 and older (Java 8)**
 
 * Go to <https://www.java.com/en/download/manual.jsp>
-* Download the `Mac OS X` package.
+* Download the `Mac OS X` package. Make sure to download the x64 as ARM is currently not supported.
 * Install it.
 
 &nbsp;
 
 # Linux
 
-### **Minecraft 24w14a and newer (Java 21)**
+### **Minecraft 1.20.5 and newer (Java 21)**
 
 `temurin-21-jdk`
+
 
 ### **Minecraft 1.17 until 1.20.4 (Java 17)**
 
@@ -82,13 +85,9 @@ For least amount of issues, choose **.pkg** download.
 * Arch `jre17-openjdk`
 * Fedora `java-17-openjdk`
 * OpenSUSE: `java-17-openjdk`
-
-
-
-
+&nbsp;
 
 ### **Minecraft 1.16 and older (Java 8)**
-
 
 * Ubuntu/Debian derivatives: `openjdk-8-jre`
 * Arch `jre8-openjdk`
@@ -96,7 +95,6 @@ For least amount of issues, choose **.pkg** download.
 * OpenSUSE: `java-1.8.0-openjdk`
 
 **Do not choose the headless version as that is designed for servers and not general use.**
-
 &nbsp;
 
 

--- a/_Footer.md
+++ b/_Footer.md
@@ -1,1 +1,1 @@
-Copyright © 2021 MultiMC Contributors
+Copyright © 2024 MultiMC Contributors


### PR DESCRIPTION
Addresses the new version requirement for Java 21 on Minecraft 1.20.5 and above.

- Changes the recommended Java to each Operating System to `Eclipse Temurin` while moving the old suggestion under `Other Distributions`. 
- Changes formatting in some locations to make things easier to read.
- This also moves some descriptions around to put them ahead of the downloads instead of after to prevent confusion (example: M1/M2/M3 Mac warning)
- Updates Copyright year (see _footer.md)